### PR TITLE
fix: imported images

### DIFF
--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -111,11 +111,12 @@ export async function loadQuizBlob(file: Blob): Promise<CreateDataRuntime> {
 
     // Add the image to the image store
     imageStore.update((store) => {
-      // Update the data store
-      store.push({ uuid, name, size, blob });
-
       // Remove duplicates from loading the file again
-      return store.filter((value) => value.uuid !== uuid);
+      const filtered = store.filter((value) => value.uuid !== uuid);
+
+      // Add the new item
+      const item = { uuid, name, size, blob };
+      return [...filtered, item];
     });
 
     // Trigger the image preview loading


### PR DESCRIPTION
## Description

Images imported from an exported quizler file were being loaded but then subsequently unloaded by mistake


## Changes

- Corrected image store logic for adding loaded images

## Related Issues

- Closes #2 