### PR TITLE
feat: session resuming

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -173,6 +173,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -430,7 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -530,6 +536,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -937,7 +954,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1067,13 +1084,16 @@ name = "quizler"
 version = "0.1.3"
 dependencies = [
  "axum",
+ "base64ct",
  "bytes",
  "dotenvy",
  "embeddy",
  "env_logger",
  "futures-util",
  "log",
+ "parking_lot",
  "rand 0.10.1",
+ "ring",
  "rustrict",
  "serde",
  "serde_json",
@@ -1188,6 +1208,20 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1363,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1471,7 +1505,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1639,6 +1673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,7 +1840,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1811,12 +1851,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,7 +42,15 @@ embeddy = "0.1.1"
 rustrict = "0.7.7"
 thiserror = "2"
 
+# Unique IDs
 uuid = { version = "1.22.0", features = ["v4", "fast-rng", "serde"] }
+
+# Fast locking primitives without panic poisoning
+parking_lot = "0.12.5"
+
+# Crypto for signing keys to make tokens and base64 to encode them
+ring = "0.17.14"
+base64ct = { version = "1.8.3", features = ["alloc"] }
 
 [profile.release]
 strip = true

--- a/backend/src/game.rs
+++ b/backend/src/game.rs
@@ -159,6 +159,84 @@ impl Game {
         });
     }
 
+    /// Handle resuming the game session for the player by `session_id` sends the
+    /// relevant information to get the player up to speed
+    pub fn resume_player(&self, session_id: SessionId) {
+        let host = self.host.id == session_id;
+
+        let mut target_addr: Option<&EventTarget> = None;
+        let mut target_player: Option<&PlayerSession> = None;
+
+        if host {
+            target_addr = Some(&self.host.addr);
+        } else {
+            for player in &self.players {
+                if player.id == session_id {
+                    target_addr = Some(&player.addr);
+                    target_player = Some(player);
+                    break;
+                }
+            }
+        }
+
+        let target_addr = match target_addr {
+            Some(player) => player,
+            None => return,
+        };
+
+        // Notify the player they have resumed a game
+        target_addr.send(Arc::new(ServerEvent::ResumedGame {
+            id: session_id,
+            host,
+            token: self.token,
+            config: self.config.clone(),
+            name: target_player.as_ref().map(|player| player.name.clone()),
+        }));
+
+        // Notify the player of all the other players in the game
+        for player in &self.players {
+            target_addr.send(Arc::new(ServerEvent::PlayerData {
+                id: player.id,
+                name: player.name.clone(),
+            }));
+        }
+
+        // Update everyone's scores
+        // (Must come before game state so that the frontend can compute finished scores)
+        let scores: Vec<(SessionId, u32)> = self
+            .players
+            .iter()
+            .map(|player| (player.id, player.score))
+            .collect();
+        let scores = ScoreCollection(scores);
+        target_addr.send(Arc::new(ServerEvent::Scores { scores }));
+
+        // Send the player the current game state
+        target_addr.send(Arc::new(ServerEvent::GameState { state: self.state }));
+
+        match self.state {
+            // Send the current question to the player for states that depend on one
+            GameState::Starting
+            | GameState::AwaitingReady
+            | GameState::PreQuestion
+            | GameState::Marked => {
+                let question = self.config.questions[self.question_index].clone();
+                target_addr.send(Arc::new(ServerEvent::Question { question }));
+
+                // Provide the answer score if the question has been scored
+                // (Only for players and not the host)
+                if let Some(target_player) = target_player {
+                    let answer = target_player.answers.get_answer_ref(self.question_index);
+                    if let Some(score) = answer.score {
+                        target_addr.send(Arc::new(ServerEvent::Score { score }));
+                    }
+                }
+            }
+
+            _ => {}
+        }
+    }
+
     /// Moves the game to the next state based on its current state
     fn next_state(&mut self) {
         // Cancel a delayed task if one is running
@@ -718,6 +796,16 @@ impl PlayerAnswers {
     fn get_answer(&mut self, index: usize) -> &mut PlayerAnswer {
         debug_assert!(index < self.values.len());
         &mut self.values[index]
+    }
+
+    /// Provides a borrow to the player answer at the provided
+    /// index
+    ///
+    /// # Arguments
+    /// * index - The index of the answer within the values array
+    fn get_answer_ref(&self, index: usize) -> &PlayerAnswer {
+        debug_assert!(index < self.values.len());
+        &self.values[index]
     }
 
     /// Checks if theres an answer stored at the provided index

--- a/backend/src/http.rs
+++ b/backend/src/http.rs
@@ -2,12 +2,13 @@ use crate::{
     game::GameConfig,
     games::Games,
     session::Session,
+    session_store::{SessionStore, SessionStoreMessage},
     types::{GameToken, ImStr, Image, NameFiltering, Question},
 };
 use axum::{
-    Json, Router,
+    Extension, Json, Router,
     body::Body,
-    extract::{Multipart, Path, WebSocketUpgrade, multipart::MultipartError},
+    extract::{Multipart, Path, Query, WebSocketUpgrade, multipart::MultipartError},
     http::{HeaderValue, Request, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -15,7 +16,7 @@ use axum::{
 use bytes::BytesMut;
 use embeddy::Embedded;
 use futures_util::TryStreamExt;
-use log::debug;
+use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -25,6 +26,7 @@ use std::{
     task::{Context, Poll},
 };
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
 use tower::Service;
 use uuid::Uuid;
 
@@ -203,11 +205,39 @@ async fn quiz_image(Path((token, uuid)): Path<(GameToken, Uuid)>) -> Result<Resp
     Ok(res)
 }
 
+#[derive(Deserialize)]
+struct SocketQuery {
+    /// Optional resumption token to attempt to resume an
+    /// existing session
+    resume: Option<String>,
+}
+
 /// # GET /api/quiz/socket
 ///
 /// Endpoint for creating a new websocket session
-async fn quiz_socket(ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(Session::start)
+async fn quiz_socket(
+    Extension(session_store): Extension<Arc<SessionStore>>,
+    Query(query): Query<SocketQuery>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(async move |socket| {
+        let socket = if let Some(resume) = query.resume
+            && let Ok(session_id) = session_store.verify_session_token(&resume)
+            && let Some(session_tx) = session_store.get_session_tx(session_id)
+        {
+            match session_tx.send(SessionStoreMessage::Reconnect { socket }) {
+                // Session was resumed we can return early
+                Ok(_) => return,
+
+                // Session could not be reached, it must be closed return to starting fresh
+                Err(SendError(SessionStoreMessage::Reconnect { socket })) => socket,
+            }
+        } else {
+            socket
+        };
+
+        Session::start(socket, session_store).await;
+    })
 }
 
 /// Embedded assets for serving the frontend of the application

--- a/backend/src/http.rs
+++ b/backend/src/http.rs
@@ -16,7 +16,7 @@ use axum::{
 use bytes::BytesMut;
 use embeddy::Embedded;
 use futures_util::TryStreamExt;
-use log::{debug, info};
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,8 @@
-use crate::games::Games;
-use axum::extract::DefaultBodyLimit;
+use crate::{games::Games, session_store::SessionStore, signing::SigningKey};
+use axum::{Extension, extract::DefaultBodyLimit};
 use dotenvy::dotenv;
 use log::{LevelFilter, error, info};
-use std::{net::Ipv4Addr, process::exit};
+use std::{net::Ipv4Addr, process::exit, sync::Arc};
 use tokio::net::TcpListener;
 
 mod game;
@@ -10,6 +10,8 @@ mod games;
 mod http;
 mod msg;
 mod session;
+mod session_store;
+mod signing;
 mod types;
 
 // Cargo package version
@@ -30,6 +32,9 @@ async fn main() {
 
     // Spawn the cleanup future
     tokio::spawn(Games::tick_cleanup());
+
+    let signing_key = SigningKey::generate();
+    let session_store = Arc::new(SessionStore::new(signing_key));
 
     let port: u16 = std::env::var("QUIZLER_PORT")
         .map(|value| {
@@ -53,7 +58,9 @@ async fn main() {
         log::debug!("custom max http body size is set = {max_body_size_byte}")
     }
 
-    let router = http::router().layer(DefaultBodyLimit::max(max_body_size_byte));
+    let router = http::router()
+        .layer(DefaultBodyLimit::max(max_body_size_byte))
+        .layer(Extension(session_store));
 
     // Add CORS and tracing layer to the router in debug mode
     #[cfg(debug_assertions)]

--- a/backend/src/msg.rs
+++ b/backend/src/msg.rs
@@ -126,10 +126,3 @@ pub enum ServerEvent {
         config: Arc<GameConfig>,
     },
 }
-
-// On resume user must be sent:
-// - List of all players
-// - Game state
-// - Current timer state (Maybe)
-// - Current question if available
-// - Current scores

--- a/backend/src/msg.rs
+++ b/backend/src/msg.rs
@@ -106,4 +106,30 @@ pub enum ServerEvent {
         /// The reason the player was kicked
         reason: RemoveReason,
     },
+    /// Provides the token that the session can use to resume itself
+    /// if the socket is lost
+    ResumptionToken {
+        /// The token to resume with
+        token: String,
+    },
+    /// Resumed access to a game
+    ResumedGame {
+        /// The resumed session ID
+        id: SessionId,
+        /// Whether we are the game host
+        host: bool,
+        /// The resumed player name if not resuming as a host
+        name: Option<ImStr>,
+        /// The resumed game token
+        token: GameToken,
+        /// The resumed game token
+        config: Arc<GameConfig>,
+    },
 }
+
+// On resume user must be sent:
+// - List of all players
+// - Game state
+// - Current timer state (Maybe)
+// - Current question if available
+// - Current scores

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -157,7 +157,7 @@ impl Session {
                 }
 
                 // If we are disconnected run the resumption timeout future
-                _ = &mut resumption_timeout, if  self.socket.is_none()  => {
+                _ = &mut resumption_timeout, if self.socket.is_none()  => {
                     debug!("Session connection lost and exceeded resumption window, closing: {}", self.id);
                     break;
                 }

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -2,19 +2,19 @@ use crate::{
     game::GameRef,
     games::{Games, InitializedMessage},
     msg::{ClientMessage, ResponseMessage, ServerEvent, ServerResponse},
+    session_store::{SessionStore, SessionStoreMessage},
     types::{Answer, GameToken, HostAction, RemoveReason, ServerError},
 };
 use axum::extract::ws::{Message, WebSocket};
 use bytes::Bytes;
+use futures_util::future::BoxFuture;
 use log::{debug, error};
 use serde::Serialize;
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
+use thiserror::Error;
 use tokio::{
     select,
     sync::mpsc,
@@ -23,10 +23,7 @@ use tokio::{
 use uuid::Uuid;
 
 /// Type alias for numbers that represent Session ID's
-pub type SessionId = u32;
-
-/// Atomic provider for session IDs
-static SESSION_ID: AtomicU32 = AtomicU32::new(0);
+pub type SessionId = Uuid;
 
 /// Structure of a session connected to the server
 pub struct Session {
@@ -37,11 +34,17 @@ pub struct Session {
 
     /// Last heartbeat received from the client
     hb: Instant,
-    /// The underlying socket connection
-    socket: WebSocket,
+    /// The socket the session is connected to
+    socket: Option<WebSocket>,
 
     /// Receiver for receiving server events
     rx: mpsc::UnboundedReceiver<Arc<ServerEvent>>,
+
+    /// Receiver for messages from the session store (Resumptions)
+    store_rx: mpsc::UnboundedReceiver<SessionStoreMessage>,
+    /// Access to the session store to revoke access after destruction
+    session_store: Arc<SessionStore>,
+
     /// Sender for server events
     tx: EventTarget,
 }
@@ -50,25 +53,51 @@ pub struct Session {
 const HB_INTERVAL: Duration = Duration::from_secs(5);
 // Timeout for handling loss of connection
 const TIMEOUT: Duration = Duration::from_secs(15);
+// Allow sessions to continue existing for 3 minutes after the
+// socket connection was lost to allow resuming the session
+const SESSION_RESUME_TIMEOUT: Duration = Duration::from_secs(60 * 3);
+
+async fn socket_recv_or_pending(
+    session_socket: Option<&mut WebSocket>,
+) -> Option<Result<Message, axum::Error>> {
+    match session_socket {
+        Some(socket) => socket.recv().await,
+        _ => std::future::pending().await,
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("impossible state, ping received without a socket")]
+struct PingOnDeadSocket;
 
 impl Session {
     /// Handler for starting a new session from the provided websocket
     ///
     /// # Arguments
     /// * socket - The websocket to use for the session
-    pub async fn start(socket: WebSocket) {
+    pub async fn start(socket: WebSocket, session_store: Arc<SessionStore>) {
         let (tx, rx) = mpsc::unbounded_channel();
-        let id = SESSION_ID.fetch_add(1, Ordering::AcqRel);
+        let (store_tx, store_rx) = mpsc::unbounded_channel();
+        let id = Uuid::new_v4();
         debug!("Starting new session {}", id);
         let hb = Instant::now();
-        let this = Self {
+        let mut this = Self {
             id,
             game: None,
             hb,
-            socket,
+            socket: Some(socket),
             rx,
             tx: EventTarget(tx),
+            store_rx,
+            session_store,
         };
+
+        // Register the message sender with the session store
+        let token = this.session_store.add_session(id, store_tx);
+
+        // Notify the session of its resumption token
+        _ = this.send(&ServerEvent::ResumptionToken { token }).await;
+
         this.process().await;
     }
 
@@ -77,6 +106,9 @@ impl Session {
         // Heartbeat interval ticking
         let mut hb_interval = interval(HB_INTERVAL);
         hb_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Timeout for resumption
+        let mut resumption_timeout: BoxFuture<'static, ()> = Box::pin(std::future::pending());
 
         loop {
             select! {
@@ -92,25 +124,68 @@ impl Session {
                         break;
                     }
                 }
-                // Client requests
-                req = self.socket.recv() => {
+
+                // Handle socket messages if the socket is active
+                req = socket_recv_or_pending(self.socket.as_mut()) => {
                     let msg: Message = match req {
                         Some(Ok(value)) => value,
                         // Error while reading body (Skip the message)
                         Some(Err(_)) => continue,
-                        // Connection is closed break from processing
-                        None => break,
+                        // Socket has become closed
+                        None => {
+                            self.socket = None;
+                            resumption_timeout = Box::pin(tokio::time::sleep(SESSION_RESUME_TIMEOUT));
+                            continue;
+                        },
                     };
 
                     match self.handle_message(msg).await {
-                        Ok(false) | Err(_) => break,
+                        Err(_) => break,
+                        Ok(false)  => {
+                            // In debug close triggers resumption logic to allow testing
+                            // session resumption
+                            #[cfg(debug_assertions)]
+                            continue;
+
+                            // In real world situations a close is treated as the end
+                            // of the connection
+                            #[cfg(not(debug_assertions))]
+                            break;
+                        },
                         Ok(true )=> {}
                     }
                 }
-                // Heartbeat
-                _ = hb_interval.tick() => {
+
+                // If we are disconnected run the resumption timeout future
+                _ = &mut resumption_timeout, if  self.socket.is_none()  => {
+                    debug!("Session connection lost and exceeded resumption window, closing: {}", self.id);
+                    break;
+                }
+
+                // If we are disconnected wait for messages from the session store to handle a reconnect
+                store_msg = self.store_rx.recv(), if self.socket.is_none() => {
+                    let socket = match store_msg {
+                        Some(SessionStoreMessage::Reconnect { socket }) => socket,
+                        // For future variants:
+                        // Some(_) => continue,
+                        // Session store has closed our channel no possible way to resume
+                        None => break,
+                    };
+
+                    // We are reconnected
+                    self.socket = Some(socket);
+                    self.hb = Instant::now();
+
+                    self.resume().await;
+                }
+
+                // Heartbeat, only if we are connected
+                _ = hb_interval.tick(), if self.socket.is_some() => {
                     if !self.heartbeat().await {
-                        break;
+                        // Socket heartbeat has failed, consider the socket dead
+                        self.socket = None;
+                        resumption_timeout = Box::pin(tokio::time::sleep(SESSION_RESUME_TIMEOUT));
+                        continue;
                     }
                 }
             };
@@ -118,14 +193,28 @@ impl Session {
         self.cleanup().await;
     }
 
+    /// Resume all information about the session sending all the
+    /// current details to the player
+    async fn resume(&mut self) {
+        if let Some(game) = self.game.as_ref() {
+            let game = game.read().await;
+            game.resume_player(self.id);
+        }
+    }
+
     /// Heartbeat returns false if connection is failed
     async fn heartbeat(&mut self) -> bool {
+        let socket = match &mut self.socket {
+            Some(socket) => socket,
+            _ => return false,
+        };
+
         let elapsed = self.hb.elapsed();
         if elapsed >= TIMEOUT {
             // Connection lost timeout
             false
         } else {
-            self.socket.send(Message::Ping(Bytes::new())).await.is_ok()
+            socket.send(Message::Ping(Bytes::new())).await.is_ok()
         }
     }
 
@@ -135,6 +224,9 @@ impl Session {
     /// Removes the player from its game if its present
     async fn cleanup(&mut self) {
         debug!("Session stopped: {}", self.id);
+
+        self.session_store.remove_session(self.id);
+
         // Take the game to attempt removing if present
         if let Some(game) = self.game.take() {
             let mut lock = game.write().await;
@@ -175,8 +267,15 @@ impl Session {
         let text = match msg {
             Message::Text(value) => value,
             Message::Ping(ping) => {
+                let socket = match &mut self.socket {
+                    Some(socket) => socket,
+
+                    // This technically should be an impossible state
+                    _ => return Err(axum::Error::new(PingOnDeadSocket)),
+                };
+
                 // If sending pong failed break
-                if self.socket.send(Message::Pong(ping)).await.is_err() {
+                if socket.send(Message::Pong(ping)).await.is_err() {
                     return Ok(false);
                 }
                 return Ok(true);
@@ -237,7 +336,11 @@ impl Session {
     /// * msg - The message to send
     async fn send<S: Serialize>(&mut self, msg: &S) -> Result<(), axum::Error> {
         let value = serde_json::to_string(msg).map_err(|err| axum::Error::new(Box::new(err)))?;
-        self.socket.send(Message::Text(value.into())).await
+        let message = Message::Text(value.into());
+        match &mut self.socket {
+            Some(socket) => socket.send(message).await,
+            None => Ok(()),
+        }
     }
 
     /// Handler for initialize messages to attempt to initialize a new game.

--- a/backend/src/session_store.rs
+++ b/backend/src/session_store.rs
@@ -1,0 +1,126 @@
+use std::{collections::HashMap, sync::Arc};
+
+use axum::extract::ws::WebSocket;
+use base64ct::{Base64UrlUnpadded, Encoding};
+use parking_lot::Mutex;
+use thiserror::Error;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::{session::SessionId, signing::SigningKey};
+
+pub type SessionToken = String;
+
+pub struct SessionStore {
+    /// Signing key for signing resumption tokens
+    key: SigningKey,
+    /// Mapping from session ID to a channel for sending messages to the session
+    sessions: Arc<Mutex<HashMap<SessionId, mpsc::UnboundedSender<SessionStoreMessage>>>>,
+}
+
+impl SessionStore {
+    pub fn new(key: SigningKey) -> Self {
+        Self {
+            key,
+            sessions: Default::default(),
+        }
+    }
+
+    fn generate_session_token(&self, session_id: SessionId) -> SessionToken {
+        let data: &[u8; 16] = session_id.as_bytes();
+
+        // Encode the message
+        let msg = Base64UrlUnpadded::encode_string(data);
+
+        // Create a signature from the raw message bytes
+        let sig = self.key.sign(data);
+        let sig = Base64UrlUnpadded::encode_string(sig.as_ref());
+
+        // Join the message and signature to create the token
+        [msg, sig].join(".")
+    }
+
+    /// Verifies an association token
+    pub fn verify_session_token(&self, token: &str) -> Result<SessionId, VerifyError> {
+        // Split the token parts
+        let (msg_raw, sig_raw) = match token.split_once('.') {
+            Some(value) => value,
+            None => return Err(VerifyError::Invalid),
+        };
+
+        // Decode the 16 byte token message
+        let mut msg = [0u8; 16];
+        Base64UrlUnpadded::decode(msg_raw, &mut msg).map_err(|_| VerifyError::Invalid)?;
+
+        // Decode 32byte signature (SHA256)
+        let mut sig = [0u8; 32];
+        Base64UrlUnpadded::decode(sig_raw, &mut sig).map_err(|_| VerifyError::Invalid)?;
+
+        // Verify the signature
+        if !self.key.verify(&msg, &sig) {
+            return Err(VerifyError::Invalid);
+        }
+        let uuid = *Uuid::from_bytes_ref(&msg);
+        Ok(uuid)
+    }
+
+    pub fn get_session_tx(
+        &self,
+        session_id: SessionId,
+    ) -> Option<mpsc::UnboundedSender<SessionStoreMessage>> {
+        self.sessions.lock().get(&session_id).cloned()
+    }
+
+    /// Add the session sender into the store for the provided `session_id`
+    pub fn add_session(
+        &self,
+        session_id: SessionId,
+        tx: mpsc::UnboundedSender<SessionStoreMessage>,
+    ) -> SessionToken {
+        let token = self.generate_session_token(session_id);
+        self.sessions.lock().insert(session_id, tx);
+        token
+    }
+
+    // Remove a session sender from the session store
+    pub fn remove_session(&self, session_id: SessionId) {
+        self.sessions.lock().remove(&session_id);
+    }
+}
+
+/// Messages that the session store can send to a session
+pub enum SessionStoreMessage {
+    /// Message for a socket reconnection using a specific sessions
+    Reconnect {
+        /// The socket the session has been resumed from
+        socket: WebSocket,
+    },
+}
+
+/// Errors that can occur while verifying a token
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    /// The token is invalid
+    #[error("token is invalid")]
+    Invalid,
+}
+
+#[cfg(test)]
+mod test {
+    use uuid::Uuid;
+
+    use crate::{session_store::SessionStore, signing::SigningKey};
+
+    /// Tests that tokens can be created and verified correctly
+    #[test]
+    fn test_token() {
+        let key = SigningKey::generate();
+        let sessions = SessionStore::new(key);
+
+        let player_id = Uuid::new_v4();
+        let token = sessions.generate_session_token(player_id);
+        let claim = sessions.verify_session_token(&token).unwrap();
+
+        assert_eq!(player_id, claim)
+    }
+}

--- a/backend/src/signing.rs
+++ b/backend/src/signing.rs
@@ -1,0 +1,38 @@
+use rand::TryRng;
+use ring::hmac::{self, HMAC_SHA256, Key, Tag};
+
+pub struct SigningKey(Key);
+
+impl AsRef<Key> for SigningKey {
+    fn as_ref(&self) -> &Key {
+        &self.0
+    }
+}
+
+impl SigningKey {
+    const KEY_LENGTH: usize = 64;
+
+    #[inline]
+    fn new(secret: &[u8; Self::KEY_LENGTH]) -> Self {
+        Self(Key::new(HMAC_SHA256, secret))
+    }
+
+    #[inline]
+    pub fn sign(&self, data: &[u8]) -> Tag {
+        hmac::sign(&self.0, data)
+    }
+
+    #[inline]
+    pub fn verify(&self, data: &[u8], tag: &[u8]) -> bool {
+        hmac::verify(&self.0, data, tag).is_ok()
+    }
+
+    /// Generates a new signing key
+    pub fn generate() -> Self {
+        let mut secret = [0; Self::KEY_LENGTH];
+        rand::rngs::SysRng
+            .try_fill_bytes(&mut secret)
+            .expect("failed to fill secret bytes");
+        Self::new(&secret)
+    }
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,8 @@
   import stateContext from "$lib/context/state";
   import { createSocketState } from "$lib/stores/socket.svelte";
   import socketContext from "$lib/context/socket";
+  import { onMount } from "svelte";
+  import { ServerEvent } from "$lib/api/models";
 
   const state = createAppState();
   const socket = createSocketState(state);
@@ -18,6 +20,26 @@
 
   stateContext.set(state);
   socketContext.set(socket);
+
+  onMount(() => {
+    const abortController = new AbortController();
+    const abortSignal = abortController.signal;
+
+    socket.setHandler(
+      ServerEvent.ResumedGame,
+      (msg) => {
+        console.debug("Resumed Game", msg);
+
+        const { id, host, token, config, name } = msg;
+        state.setGame({ id, token, config, host, name: name ?? undefined });
+      },
+      abortSignal
+    );
+
+    return () => {
+      abortController.abort();
+    };
+  });
 </script>
 
 {#if socket.ready}

--- a/frontend/src/lib/api/actions.ts
+++ b/frontend/src/lib/api/actions.ts
@@ -4,7 +4,7 @@ import type { GameData } from "$pages/Game.svelte";
 import { confirmDialog } from "$stores/dialogStore";
 import { type AppStateStore } from "$stores/state.svelte";
 
-export async function doKick(socket: SocketStore, id: number) {
+export async function doKick(socket: SocketStore, id: string) {
   try {
     await socket.send({
       ty: ClientMessage.Kick,

--- a/frontend/src/lib/api/models.ts
+++ b/frontend/src/lib/api/models.ts
@@ -12,7 +12,7 @@ import type { SHADOW_ITEM_MARKER_PROPERTY_NAME } from "svelte-dnd-action";
 import { z } from "zod";
 
 // Represents a unique ID of a session
-export type SessionId = number;
+export type SessionId = string;
 
 // Represents a 5 character game token (e.g EAU32)
 export type GameToken = string;
@@ -348,7 +348,9 @@ export const enum ServerEvent {
   Question = "Question",
   Scores = "Scores",
   Score = "Score",
-  Kicked = "Kicked"
+  Kicked = "Kicked",
+  ResumptionToken = "ResumptionToken",
+  ResumedGame = "ResumedGame"
 }
 
 // Server response message type
@@ -360,7 +362,7 @@ export const enum ServerResponse {
 
 // Server message schema based on each message type
 export type ServerEventSchema = { ret: undefined } & (
-  | { ty: ServerEvent.PlayerData; id: number; name: string }
+  | { ty: ServerEvent.PlayerData; id: SessionId; name: string }
   | { ty: ServerEvent.GameState; state: GameState }
   | {
       ty: ServerEvent.Timer;
@@ -369,7 +371,16 @@ export type ServerEventSchema = { ret: undefined } & (
   | { ty: ServerEvent.Question; question: Question }
   | { ty: ServerEvent.Scores; scores: Scores }
   | { ty: ServerEvent.Score; score: Score }
-  | { ty: ServerEvent.Kicked; id: number; reason: RemoveReason }
+  | { ty: ServerEvent.Kicked; id: SessionId; reason: RemoveReason }
+  | { ty: ServerEvent.ResumptionToken; token: string }
+  | {
+      ty: ServerEvent.ResumedGame;
+      id: SessionId;
+      host: boolean;
+      name: string | null;
+      token: string;
+      config: GameConfig;
+    }
 );
 
 // Server message type extractor
@@ -383,7 +394,12 @@ export function isServerEventType<T extends ServerEvent>(
 }
 
 export type ServerResponseSchema = { ret: 1 } & (
-  | { ty: ServerResponse.Joined; id: number; token: string; config: GameConfig }
+  | {
+      ty: ServerResponse.Joined;
+      id: SessionId;
+      token: string;
+      config: GameConfig;
+    }
   | { ty: ServerResponse.Ok }
   | { ty: ServerResponse.Error; error: ServerError }
 );

--- a/frontend/src/lib/stores/socket.svelte.ts
+++ b/frontend/src/lib/stores/socket.svelte.ts
@@ -69,14 +69,17 @@ interface TypedHandlerWithAbort<K extends ServerEvent> {
 export function createSocketState(appState: AppStateStore): SocketStore {
   let ready = $state(false);
 
+  // Token for resuming the connection
+  let resumptionToken: string | null = null;
+
   // Handler for the next response
   let responseHandle: RequestHandler<unknown> | null = null;
   // Queue of messages that haven't yet been handled
   let messageQueue: ServerMessage[] = [];
 
   // Currently set message handlers for handling messages
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const messageHandlers: Partial<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Record<ServerEvent, TypedHandlerWithAbort<any>>
   > = {};
 
@@ -100,7 +103,17 @@ export function createSocketState(appState: AppStateStore): SocketStore {
    * the event handlers for the different events
    */
   function createSocket(): WebSocket {
-    const socketUrl = getServerURL("/api/quiz/socket");
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- This is not reactive code it doesn't need it
+    const params = new URLSearchParams();
+
+    if (resumptionToken !== null) {
+      params.set("resume", resumptionToken);
+    }
+
+    const socketParams = params.size > 0 ? `?${params.toString()}` : "";
+    const socketPath = `/api/quiz/socket${socketParams}`;
+
+    const socketUrl = getServerURL(socketPath);
     // Replace the url protocol with the correct socket protocol
     socketUrl.protocol = socketUrl.protocol.includes("https") ? "wss" : "ws";
 
@@ -270,6 +283,10 @@ export function createSocketState(appState: AppStateStore): SocketStore {
 
     return destructor;
   }
+
+  setHandler(ServerEvent.ResumptionToken, (event) => {
+    resumptionToken = event.token;
+  });
 
   return {
     get ready() {

--- a/frontend/src/lib/stores/socket.svelte.ts
+++ b/frontend/src/lib/stores/socket.svelte.ts
@@ -70,7 +70,8 @@ export function createSocketState(appState: AppStateStore): SocketStore {
   let ready = $state(false);
 
   // Token for resuming the connection
-  let resumptionToken: string | null = null;
+  let resumptionToken: string | null =
+    sessionStorage.getItem("resumptionToken");
 
   // Handler for the next response
   let responseHandle: RequestHandler<unknown> | null = null;
@@ -286,6 +287,7 @@ export function createSocketState(appState: AppStateStore): SocketStore {
 
   setHandler(ServerEvent.ResumptionToken, (event) => {
     resumptionToken = event.token;
+    sessionStorage.setItem("resumptionToken", resumptionToken);
   });
 
   return {


### PR DESCRIPTION
## Description

Allows sessions to be resumed instead of immediately treating disconnected sockets as removed forever, gives sessions are grace period to be resumed using an access token to handle cases like mobile phones switching tabs and disconnecting the socket or spotty network connections

## Related Issues

- #8 