### PR TITLE
Feat macos release action and version bump

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -193,10 +193,76 @@ jobs:
                   name: ${{ matrix.filename }}
                   path: ${{ matrix.filename }}
 
+    build-macos:
+        name: Build MacOS targets
+        runs-on: macos-latest
+        needs: [build-frontend]
+        strategy:
+            matrix:
+                include:
+                    - target: aarch64-apple-darwin
+                      os_name: macos
+                      arch: aarch64
+                      filename: quizler-aarch64-apple-darwin
+
+                    - target: x86_64-apple-darwin
+                      os_name: macos
+                      arch: x86_64
+                      filename: quizler-x86_64-apple-darwin
+
+        steps:
+            # Checkout the repo for building
+            - uses: actions/checkout@v4
+
+            # Download the frontend build artifact
+            - name: Download frontend artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: frontend-build
+                  merge-multiple: true
+                  path: backend/public/
+
+            # Setup rust for building the service
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  targets: ${{ matrix.target }}
+
+            # Cache Rust dependencies and build artifacts
+            - name: Cache Rust dependencies
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                      target/
+                  key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+            # Cross compile the binary
+            - name: Build
+              working-directory: backend
+              run: cargo build --release --target ${{ matrix.target }} -p quizler
+
+            # Copy built binary to output directory
+            - name: Rename and move output binary
+              run: cp backend/target/${{ matrix.target }}/release/quizler ${{ matrix.filename }}
+              shell: bash
+
+            # Upload the built artifact
+            - name: Upload binary artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ matrix.filename }}
+                  path: ${{ matrix.filename }}
+
     release:
         name: Create Release
         runs-on: ubuntu-latest
-        needs: [build-linux, build-windows]
+        needs: [build-linux, build-windows, build-macos]
 
         steps:
             # Checkout the repo

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "quizler"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "axum",
  "base64ct",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quizler"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 description = "Offline quiz game"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quizler",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "Real-time quiz application",
     "repository": "https://github.com/jacobtread/Quizler.git",
     "author": "Jacobtread <jacobtread@gmail.com>",


### PR DESCRIPTION
## Description

Adds macos targets to the release CI action since quizler is supported for running on macos platforms

## Changes

- Adds job to build macos targets